### PR TITLE
Npguard semantic diff 2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/np-guard/cluster-topology-analyzer v1.7.0
-	github.com/np-guard/netpol-analyzer v0.4.2
+	github.com/np-guard/netpol-analyzer v0.4.3
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1205,8 +1205,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/np-guard/cluster-topology-analyzer v1.7.0 h1:MtXZ7XF8EFQbM8uJO+RCS6KnArk88Rn4U0CnuFWu7BM=
 github.com/np-guard/cluster-topology-analyzer v1.7.0/go.mod h1:WDOpAZdQcD4t61J4ZsG9BoXhlG04sqKTZgkohng0p3A=
-github.com/np-guard/netpol-analyzer v0.4.2 h1:PAtryJzHzYWXgtHurjz2KERwXD0xry9GU/SpKDISfVw=
-github.com/np-guard/netpol-analyzer v0.4.2/go.mod h1:2MUl7DNbq01PGJLi7PJbzlEIcI72jwchzTGzazoIio8=
+github.com/np-guard/netpol-analyzer v0.4.3 h1:D8ad4TfQv3QIGKc+wfKb3T+ES8YX6fIJfnKAD7He8a8=
+github.com/np-guard/netpol-analyzer v0.4.3/go.mod h1:2MUl7DNbq01PGJLi7PJbzlEIcI72jwchzTGzazoIio8=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/roxctl/connectivity-diff/README.md
+++ b/roxctl/connectivity-diff/README.md
@@ -14,7 +14,7 @@ It is based on [NP-Guard's Network Policy Analyzer component](https://github.com
 
 ## Command Objective
 
-Generate a file that allows users to visualize the **connectivity-diff** between two versions of workloads and network policy manifests. 
+Generate a file that allows users to visualize the **connectivity-diff** between two versions of workloads and network policy manifests.
 
 ## Usage
 
@@ -26,7 +26,7 @@ The manifests must not be templated (e.g., Helm charts) to be considered. All YA
 
 
 
-#### Syntactic vs semantic diff: 
+#### Syntactic vs semantic diff:
 
 The example shown below has two versions, where `dir1` is `netpol-analysis-example-minimal/` , and `dir2` is  `netpol-diff-example-minimal/`.
 The difference between the dirs consists of a small change in network policy `backend-netpol`.
@@ -104,15 +104,14 @@ The semantic-diff report provides a summary of changed/added/removed connections
 
 
 ### Understanding the output
-Each line in the output represents an allowed connection that has been added/removed/changed on `dir2` with respect to `dir1`. 
+Each line in the output represents an allowed connection that has been added/removed/changed on `dir2` with respect to `dir1`.
 
 ## Parameters
 
 The output can be redirected to a file by using `--output-file` parameter.
 
-The output format can be set by using the `--output-format` parameter. Supported output formats: `txt, md, csv`. 
+The output format can be set by using the `--output-format` parameter. Supported output formats: `txt, md, csv`.
 
 When running in a CI pipeline, roxctl `connectivity-diff` may benefit from the `--fail` option that stops the processing on the first encountered error.
 
 Using the `--strict` parameter produces an error "there were errors during execution" if any warnings appeared during the processing. Note that the combination of `--strict` and `--fail` will not stop on the first warning, as the interpretation of warnings as errors happens at the end of execution.
-

--- a/roxctl/connectivity-diff/netpol.go
+++ b/roxctl/connectivity-diff/netpol.go
@@ -41,7 +41,7 @@ Red Hat does not recommend using them in production.
 These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/`,
 
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			diffNetpolCmd.env.Logger().WarnfLn("This is a Technology Preview feature. Red Hat does not recommend using Technology Preview features in production.")
 			analyzer, err := diffNetpolCmd.construct(args)
@@ -55,6 +55,8 @@ For more information about the support scope of Red Hat Technology Preview featu
 		},
 	}
 
+	c.Flags().StringVarP(&diffNetpolCmd.inputFolderPath1, "dir1", "", "", "first resources dir path")
+	c.Flags().StringVarP(&diffNetpolCmd.inputFolderPath2, "dir2", "", "", "second resources dir path to be compared with the first dir path")
 	c.Flags().BoolVar(&diffNetpolCmd.treatWarningsAsErrors, "strict", false, "treat warnings as errors")
 	c.Flags().BoolVar(&diffNetpolCmd.stopOnFirstError, "fail", false, "fail on the first encountered error")
 	c.Flags().BoolVar(&diffNetpolCmd.removeOutputPath, "remove", false, "remove the output path if it already exists")
@@ -65,8 +67,6 @@ For more information about the support scope of Red Hat Technology Preview featu
 }
 
 func (cmd *diffNetpolCommand) construct(args []string) (diffAnalyzer, error) {
-	cmd.inputFolderPath1 = args[0]
-	cmd.inputFolderPath2 = args[1]
 	var opts []npguard.DiffAnalyzerOption
 	if cmd.env != nil && cmd.env.Logger() != nil {
 		opts = append(opts, npguard.WithLogger(npg.NewLogger(cmd.env.Logger())))
@@ -84,6 +84,9 @@ func (cmd *diffNetpolCommand) construct(args []string) (diffAnalyzer, error) {
 }
 
 func (cmd *diffNetpolCommand) validate() error {
+	if cmd.inputFolderPath1 == "" || cmd.inputFolderPath2 == "" {
+		return errors.New("both directory paths dir1 and dir2 are required")
+	}
 	if err := cmd.setupPath(cmd.outputFilePath); err != nil {
 		return errors.Wrap(err, "failed to set up file path")
 	}

--- a/roxctl/connectivity-diff/netpol.go
+++ b/roxctl/connectivity-diff/netpol.go
@@ -30,7 +30,7 @@ type diffNetpolCommand struct {
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	diffNetpolCmd := &diffNetpolCommand{env: cliEnvironment}
 	c := &cobra.Command{
-		Use:   "connectivity-diff <folder-path1> <folder-path2>",
+		Use:   "connectivity-diff --dir1=<folder-path1> --dir2=<folder-path2>",
 		Short: "(Technology Preview) Report connectivity diff based on two directories of network policies and workload resources YAML manifests.",
 		Long: `Based on given two folders containing Kubernetes workloads and network policy YAMLs, will report all differences in allowed connections between the directories.
 		Will write to stdout if no output flags are provided.

--- a/roxctl/connectivity-diff/netpol.go
+++ b/roxctl/connectivity-diff/netpol.go
@@ -84,8 +84,11 @@ func (cmd *diffNetpolCommand) construct(args []string) (diffAnalyzer, error) {
 }
 
 func (cmd *diffNetpolCommand) validate() error {
-	if cmd.inputFolderPath1 == "" || cmd.inputFolderPath2 == "" {
-		return errors.New("both directory paths dir1 and dir2 are required")
+	if cmd.inputFolderPath1 == "" {
+		return errors.New("directory path dir1 is required")
+	}
+	if cmd.inputFolderPath2 == "" {
+		return errors.New("directory path dir2 is required")
 	}
 	if err := cmd.setupPath(cmd.outputFilePath); err != nil {
 		return errors.Wrap(err, "failed to set up file path")

--- a/roxctl/connectivity-diff/netpol.go
+++ b/roxctl/connectivity-diff/netpol.go
@@ -32,7 +32,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "connectivity-diff <folder-path1> <folder-path2>",
 		Short: "(Technology Preview) Report connectivity diff based on two directories of network policies and workload resources YAML manifests.",
-		Long: `Based on given two folders containing Kubernetes workloads and network policy YAMLs, will report all differences in allowed connections between the directories. 
+		Long: `Based on given two folders containing Kubernetes workloads and network policy YAMLs, will report all differences in allowed connections between the directories.
 		Will write to stdout if no output flags are provided.
 
 ** This is a Technology Preview feature **

--- a/roxctl/connectivity-diff/netpol_test.go
+++ b/roxctl/connectivity-diff/netpol_test.go
@@ -174,8 +174,8 @@ func (d *diffAnalyzeNetpolTestSuite) TestDiffAnalyzeNetpol() {
 			diffNetpolCmd := diffNetpolCommand{
 				stopOnFirstError:      tt.stopOnFirstErr,
 				treatWarningsAsErrors: tt.strict,
-				inputFolderPath1:      "", // set through construct
-				inputFolderPath2:      "", // set through construct
+				inputFolderPath1:      tt.inputFolderPath1,
+				inputFolderPath2:      tt.inputFolderPath2,
 				outputFilePath:        tt.outFile,
 				removeOutputPath:      tt.removeOutputPath,
 				outputToFile:          tt.outputToFile,
@@ -183,7 +183,7 @@ func (d *diffAnalyzeNetpolTestSuite) TestDiffAnalyzeNetpol() {
 				env:                   env,
 			}
 
-			analyzer, err := diffNetpolCmd.construct([]string{tt.inputFolderPath1, tt.inputFolderPath2})
+			analyzer, err := diffNetpolCmd.construct([]string{})
 			d.Assert().NoError(err)
 
 			err = diffNetpolCmd.validate()

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/diff_output.csv
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/diff_output.csv
@@ -1,4 +1,4 @@
-source,destination,dir1,dir2,diff-type
-payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connections,TCP 8080,added (workload payments/visa-processor-v2[Deployment] added)
-{ingress-controller},frontend/blog[Deployment],No Connections,TCP 8080,added (workload frontend/blog[Deployment] added)
-{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,added (workload zeroday/zeroday[Deployment] added)
+diff-type,source,destination,dir1,dir2,workloads-diff-info
+added,payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connections,TCP 8080,workload payments/visa-processor-v2[Deployment] added
+added,{ingress-controller},frontend/blog[Deployment],No Connections,TCP 8080,workload frontend/blog[Deployment] added
+added,{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,workload zeroday/zeroday[Deployment] added

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/diff_output.md
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/diff_output.md
@@ -1,5 +1,5 @@
-| source | destination | dir1 | dir2 | diff-type |
-|--------|-------------|------|------|-----------|
-| payments/gateway[Deployment] | payments/visa-processor-v2[Deployment] | No Connections | TCP 8080 | added (workload payments/visa-processor-v2[Deployment] added) |
-| {ingress-controller} | frontend/blog[Deployment] | No Connections | TCP 8080 | added (workload frontend/blog[Deployment] added) |
-| {ingress-controller} | zeroday/zeroday[Deployment] | No Connections | TCP 8080 | added (workload zeroday/zeroday[Deployment] added) |
+| diff-type | source | destination | dir1 | dir2 | workloads-diff-info |
+|-----------|--------|-------------|------|------|---------------------|
+| added | payments/gateway[Deployment] | payments/visa-processor-v2[Deployment] | No Connections | TCP 8080 | workload payments/visa-processor-v2[Deployment] added |
+| added | {ingress-controller} | frontend/blog[Deployment] | No Connections | TCP 8080 | workload frontend/blog[Deployment] added |
+| added | {ingress-controller} | zeroday/zeroday[Deployment] | No Connections | TCP 8080 | workload zeroday/zeroday[Deployment] added |

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/diff_output.txt
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/diff_output.txt
@@ -1,4 +1,4 @@
 Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/asset-cache/deployment.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/asset-cache/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           name: asset-cache
           ports:
             - containerPort: 8080
-              protocol: TCP       
+              protocol: TCP
 ---
 apiVersion: v1
 kind: Service

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/asset-cache/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/asset-cache/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: asset-cache 
-  namespace: frontend 
+  name: asset-cache
+  namespace: frontend
   labels:
     app: asset-cache
 spec:

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/blog/deployment.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/blog/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: blog
-  namespace: frontend 
+  namespace: frontend
   labels:
     app: blog
     app.kubernetes.io/part-of: blog
@@ -52,7 +52,7 @@ metadata:
   labels:
     app: blog
   name: blog-service
-  namespace: frontend 
+  namespace: frontend
 spec:
   ports:
     - port: 8080

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/blog/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/blog/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: blog 
-  namespace: frontend 
+  name: blog
+  namespace: frontend
   labels:
     app: blog
 spec:

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/namespace.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: frontend 
+  name: frontend
   labels:
     name: frontend
     exposed: 'true'

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/webapp/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/frontend/webapp/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: webapp 
-  namespace: frontend 
+  name: webapp
+  namespace: frontend
   labels:
     app: webapp
 spec:

--- a/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/zeroday/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos-new-version/zeroday/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: zeroday 
-  namespace: zeroday 
+  name: zeroday
+  namespace: zeroday
   labels:
     app: zeroday
 spec:

--- a/roxctl/connectivity-diff/testdata/acs-security-demos/frontend/asset-cache/deployment.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos/frontend/asset-cache/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           name: asset-cache
           ports:
             - containerPort: 8080
-              protocol: TCP       
+              protocol: TCP
 ---
 apiVersion: v1
 kind: Service

--- a/roxctl/connectivity-diff/testdata/acs-security-demos/frontend/asset-cache/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos/frontend/asset-cache/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: asset-cache 
-  namespace: frontend 
+  name: asset-cache
+  namespace: frontend
   labels:
     app: asset-cache
 spec:

--- a/roxctl/connectivity-diff/testdata/acs-security-demos/frontend/webapp/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-security-demos/frontend/webapp/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: webapp 
-  namespace: frontend 
+  name: webapp
+  namespace: frontend
   labels:
     app: webapp
 spec:

--- a/roxctl/connectivity-diff/testdata/acs-zeroday-with-invalid-doc/route.yaml
+++ b/roxctl/connectivity-diff/testdata/acs-zeroday-with-invalid-doc/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: zeroday 
-  namespace: zeroday 
+  name: zeroday
+  namespace: zeroday
   labels:
     app: zeroday
 spec:

--- a/roxctl/connectivity-diff/testdata/dirty/backend.yaml
+++ b/roxctl/connectivity-diff/testdata/dirty/backend.yaml
@@ -50,4 +50,3 @@ spec:
   - name: http
     port: 9090
     targetPort: 9090
-

--- a/roxctl/connectivity-diff/testdata/netpol-analysis-example-minimal/backend.yaml
+++ b/roxctl/connectivity-diff/testdata/netpol-analysis-example-minimal/backend.yaml
@@ -50,4 +50,3 @@ spec:
   - name: http
     port: 9090
     targetPort: 9090
-

--- a/roxctl/connectivity-diff/testdata/netpol-analysis-example-minimal/netpols.yaml
+++ b/roxctl/connectivity-diff/testdata/netpol-analysis-example-minimal/netpols.yaml
@@ -62,4 +62,3 @@ spec:
   - Ingress
   - Egress
 status: {}
-

--- a/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/backend.yaml
+++ b/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/backend.yaml
@@ -50,4 +50,3 @@ spec:
   - name: http
     port: 9090
     targetPort: 9090
-

--- a/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/diff_output.csv
+++ b/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/diff_output.csv
@@ -1,3 +1,3 @@
-source,destination,dir1,dir2,diff-type
-default/frontend[Deployment],default/backend[Deployment],TCP 9090,"TCP 9090,UDP 53",changed
-0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 9090,added
+diff-type,source,destination,dir1,dir2,workloads-diff-info
+changed,default/frontend[Deployment],default/backend[Deployment],TCP 9090,"TCP 9090,UDP 53",
+added,0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 9090,

--- a/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/diff_output.md
+++ b/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/diff_output.md
@@ -1,4 +1,4 @@
-| source | destination | dir1 | dir2 | diff-type |
-|--------|-------------|------|------|-----------|
-| default/frontend[Deployment] | default/backend[Deployment] | TCP 9090 | TCP 9090,UDP 53 | changed |
-| 0.0.0.0-255.255.255.255 | default/backend[Deployment] | No Connections | TCP 9090 | added |
+| diff-type | source | destination | dir1 | dir2 | workloads-diff-info |
+|-----------|--------|-------------|------|------|---------------------|
+| changed | default/frontend[Deployment] | default/backend[Deployment] | TCP 9090 | TCP 9090,UDP 53 |  |
+| added | 0.0.0.0-255.255.255.255 | default/backend[Deployment] | No Connections | TCP 9090 |  |

--- a/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/diff_output.txt
+++ b/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/diff_output.txt
@@ -1,3 +1,3 @@
 Connectivity diff:
-source: default/frontend[Deployment], destination: default/backend[Deployment], dir1:  TCP 9090, dir2: TCP 9090,UDP 53, diff-type: changed
-source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:  No Connections, dir2: TCP 9090, diff-type: added
+diff-type: changed, source: default/frontend[Deployment], destination: default/backend[Deployment], dir1:  TCP 9090, dir2: TCP 9090,UDP 53
+diff-type: added, source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:  No Connections, dir2: TCP 9090

--- a/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/netpols.yaml
+++ b/roxctl/connectivity-diff/testdata/netpol-diff-example-minimal/netpols.yaml
@@ -62,4 +62,3 @@ spec:
   - Ingress
   - Egress
 status: {}
-

--- a/roxctl/connectivity-map/README.md
+++ b/roxctl/connectivity-map/README.md
@@ -83,12 +83,12 @@ Produced graph for the above example is depicted below:
 ### Analysis of Ingress/Route resources
 
 In addition to network policies, the connectivity analysis also considers `Kubernetes Ingress` and `Openshift Route` resources.
-For connections inferred from Ingress/Route resources, the src is specified as `{ingress-controller}`, representing the cluster's ingress controller Pod. 
+For connections inferred from Ingress/Route resources, the src is specified as `{ingress-controller}`, representing the cluster's ingress controller Pod.
 Its connectivity lines are of the form: `{ingress-controller} => dst : connections`, where `dst` is a workload in the cluster.
 This analysis assumes that the ingress controller Pod is unknown, and thus using this notation of `{ingress-controller}`.
 
-Since the analysis assumes the manifest of the ingress controller is unknown, it checks whether an arbitrary workload can access (by network policies) the destination workloads specified in Ingress/Route rules. 
-If such access is not permitted by network policies, this connection is removed from the report. 
+Since the analysis assumes the manifest of the ingress controller is unknown, it checks whether an arbitrary workload can access (by network policies) the destination workloads specified in Ingress/Route rules.
+If such access is not permitted by network policies, this connection is removed from the report.
 It may be an allowed connection if a network policy specifically allows ingress access to that workload from a specific workload/namespace of the actual ingress controller installed.
 
 ### Parameters

--- a/roxctl/connectivity-map/testdata/acs-security-demos/acs_netpols.yaml
+++ b/roxctl/connectivity-map/testdata/acs-security-demos/acs_netpols.yaml
@@ -477,4 +477,3 @@ spec:
   policyTypes:
   - Ingress
   - Egress
-

--- a/roxctl/connectivity-map/testdata/acs-security-demos/frontend/asset-cache/deployment.yaml
+++ b/roxctl/connectivity-map/testdata/acs-security-demos/frontend/asset-cache/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           name: asset-cache
           ports:
             - containerPort: 8080
-              protocol: TCP       
+              protocol: TCP
 ---
 apiVersion: v1
 kind: Service

--- a/roxctl/connectivity-map/testdata/acs-security-demos/frontend/asset-cache/route.yaml
+++ b/roxctl/connectivity-map/testdata/acs-security-demos/frontend/asset-cache/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: asset-cache 
-  namespace: frontend 
+  name: asset-cache
+  namespace: frontend
   labels:
     app: asset-cache
 spec:

--- a/roxctl/connectivity-map/testdata/acs-security-demos/frontend/webapp/route.yaml
+++ b/roxctl/connectivity-map/testdata/acs-security-demos/frontend/webapp/route.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: webapp 
-  namespace: frontend 
+  name: webapp
+  namespace: frontend
   labels:
     app: webapp
 spec:

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
@@ -40,8 +40,8 @@ teardown() {
 
 @test "roxctl-development connectivity-diff stops on first error when run with --fail" {
   mkdir -p "$out_dir"
-  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
-  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/a_templated-010-XXXXXX-file1.yaml")"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/b_templated-020-XXXXXX-file2.yaml")"
 
   run roxctl-development connectivity-diff "$out_dir/" "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
@@ -172,9 +172,9 @@ diff_tests_dir="${BATS_TEST_DIRNAME}/../../../../roxctl/connectivity-diff/testda
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)'
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added'
 }
 
 @test "roxctl-development connectivity-diff generates conns diff report between resources from two directories txt output" {
@@ -235,11 +235,10 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)'
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added'
 }
-
 
 @test "roxctl-development connectivity-diff generates conns diff report between resources from two directories md output" {
   dir1="${diff_tests_dir}/acs-security-demos/"
@@ -298,11 +297,11 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
-  assert_output --partial '| source | destination | dir1 | dir2 | diff-type |
-|--------|-------------|------|------|-----------|
-| payments/gateway[Deployment] | payments/visa-processor-v2[Deployment] | No Connections | TCP 8080 | added (workload payments/visa-processor-v2[Deployment] added) |
-| {ingress-controller} | frontend/blog[Deployment] | No Connections | TCP 8080 | added (workload frontend/blog[Deployment] added) |
-| {ingress-controller} | zeroday/zeroday[Deployment] | No Connections | TCP 8080 | added (workload zeroday/zeroday[Deployment] added) |'
+  assert_output --partial '| diff-type | source | destination | dir1 | dir2 | workloads-diff-info |
+|-----------|--------|-------------|------|------|---------------------|
+| added | payments/gateway[Deployment] | payments/visa-processor-v2[Deployment] | No Connections | TCP 8080 | workload payments/visa-processor-v2[Deployment] added |
+| added | {ingress-controller} | frontend/blog[Deployment] | No Connections | TCP 8080 | workload frontend/blog[Deployment] added |
+| added | {ingress-controller} | zeroday/zeroday[Deployment] | No Connections | TCP 8080 | workload zeroday/zeroday[Deployment] added |'
 }
 
 @test "roxctl-development connectivity-diff generates conns diff report between resources from two directories csv output" {
@@ -362,10 +361,10 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
-  assert_output --partial 'source,destination,dir1,dir2,diff-type
-payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connections,TCP 8080,added (workload payments/visa-processor-v2[Deployment] added)
-{ingress-controller},frontend/blog[Deployment],No Connections,TCP 8080,added (workload frontend/blog[Deployment] added)
-{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,added (workload zeroday/zeroday[Deployment] added)'
+  assert_output --partial 'diff-type,source,destination,dir1,dir2,workloads-diff-info
+added,payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connections,TCP 8080,workload payments/visa-processor-v2[Deployment] added
+added,{ingress-controller},frontend/blog[Deployment],No Connections,TCP 8080,workload frontend/blog[Deployment] added
+added,{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,workload zeroday/zeroday[Deployment] added'
 }
 
 @test "roxctl-development connectivity-diff hould return error on not supported output format" {
@@ -483,9 +482,9 @@ payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connectio
   assert_file_exist "$out_dir/out.txt"
   # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)'
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added'
 }
 
 @test "roxctl-development connectivity-diff generates conns diff report between resources from another two directories txt output" {
@@ -507,8 +506,8 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: default/frontend[Deployment], destination: default/backend[Deployment], dir1:  TCP 9090, dir2: TCP 9090,UDP 53, diff-type: changed
-source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:  No Connections, dir2: TCP 9090, diff-type: added'
+diff-type: changed, source: default/frontend[Deployment], destination: default/backend[Deployment], dir1:  TCP 9090, dir2: TCP 9090,UDP 53
+diff-type: added, source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:  No Connections, dir2: TCP 9090'
 }
 
 
@@ -530,10 +529,10 @@ source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
-  assert_output --partial '| source | destination | dir1 | dir2 | diff-type |
-|--------|-------------|------|------|-----------|
-| default/frontend[Deployment] | default/backend[Deployment] | TCP 9090 | TCP 9090,UDP 53 | changed |
-| 0.0.0.0-255.255.255.255 | default/backend[Deployment] | No Connections | TCP 9090 | added |'
+  assert_output --partial '| diff-type | source | destination | dir1 | dir2 | workloads-diff-info |
+|-----------|--------|-------------|------|------|---------------------|
+| changed | default/frontend[Deployment] | default/backend[Deployment] | TCP 9090 | TCP 9090,UDP 53 |  |
+| added | 0.0.0.0-255.255.255.255 | default/backend[Deployment] | No Connections | TCP 9090 |  |'
 }
 
 @test "roxctl-development connectivity-diff generates conns diff report between resources from another two directories csv output" {
@@ -554,9 +553,9 @@ source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
-  assert_output --partial 'source,destination,dir1,dir2,diff-type
-default/frontend[Deployment],default/backend[Deployment],TCP 9090,"TCP 9090,UDP 53",changed
-0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 9090,added'
+  assert_output --partial 'diff-type,source,destination,dir1,dir2,workloads-diff-info
+changed,default/frontend[Deployment],default/backend[Deployment],TCP 9090,"TCP 9090,UDP 53",
+added,0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 9090,'
 }
 
 @test "roxctl-development connectivity-diff empty diff report for two paths with same directory " {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
@@ -573,7 +573,7 @@ added,0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 909
   assert_file_exist "${dir1}/frontend.yaml"
   assert_file_exist "${dir1}/netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-development connectivity-diff --dir1="${dir1}" --dir2="${dir1}" 
+  run roxctl-development connectivity-diff --dir1="${dir1}" --dir2="${dir1}"
   assert_success
 
   echo "$output" > "$ofile"

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-development.bats
@@ -29,14 +29,14 @@ teardown() {
   run roxctl-development connectivity-diff
   assert_failure
   assert_line --partial "ERROR:"
-  assert_line --partial "both directory paths dir1 and dir2 are require"
+  assert_line --partial "directory path dir1 is required"
 }
 
 @test "roxctl-development connectivity-diff only one input directory" {
   run roxctl-development connectivity-diff --dir1="dir1"
   assert_failure
   assert_line --partial "ERROR:"
-  assert_line --partial "both directory paths dir1 and dir2 are require"
+  assert_line --partial "directory path dir2 is required"
 }
 
 @test "roxctl-development connectivity-diff non existing dirs" {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
@@ -172,11 +172,10 @@ diff_tests_dir="${BATS_TEST_DIRNAME}/../../../../roxctl/connectivity-diff/testda
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)'
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added'
 }
-
 
 @test "roxctl-release connectivity-diff generates conns diff report between resources from two directories txt output" {
   dir1="${diff_tests_dir}/acs-security-demos/"
@@ -236,11 +235,10 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)'
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added'
 }
-
 
 @test "roxctl-release connectivity-diff generates conns diff report between resources from two directories md output" {
   dir1="${diff_tests_dir}/acs-security-demos/"
@@ -299,11 +297,11 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
-  assert_output --partial '| source | destination | dir1 | dir2 | diff-type |
-|--------|-------------|------|------|-----------|
-| payments/gateway[Deployment] | payments/visa-processor-v2[Deployment] | No Connections | TCP 8080 | added (workload payments/visa-processor-v2[Deployment] added) |
-| {ingress-controller} | frontend/blog[Deployment] | No Connections | TCP 8080 | added (workload frontend/blog[Deployment] added) |
-| {ingress-controller} | zeroday/zeroday[Deployment] | No Connections | TCP 8080 | added (workload zeroday/zeroday[Deployment] added) |'
+  assert_output --partial '| diff-type | source | destination | dir1 | dir2 | workloads-diff-info |
+|-----------|--------|-------------|------|------|---------------------|
+| added | payments/gateway[Deployment] | payments/visa-processor-v2[Deployment] | No Connections | TCP 8080 | workload payments/visa-processor-v2[Deployment] added |
+| added | {ingress-controller} | frontend/blog[Deployment] | No Connections | TCP 8080 | workload frontend/blog[Deployment] added |
+| added | {ingress-controller} | zeroday/zeroday[Deployment] | No Connections | TCP 8080 | workload zeroday/zeroday[Deployment] added |'
 }
 
 @test "roxctl-release connectivity-diff generates conns diff report between resources from two directories csv output" {
@@ -363,10 +361,10 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
-  assert_output --partial 'source,destination,dir1,dir2,diff-type
-payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connections,TCP 8080,added (workload payments/visa-processor-v2[Deployment] added)
-{ingress-controller},frontend/blog[Deployment],No Connections,TCP 8080,added (workload frontend/blog[Deployment] added)
-{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,added (workload zeroday/zeroday[Deployment] added)'
+  assert_output --partial 'diff-type,source,destination,dir1,dir2,workloads-diff-info
+added,payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connections,TCP 8080,workload payments/visa-processor-v2[Deployment] added
+added,{ingress-controller},frontend/blog[Deployment],No Connections,TCP 8080,workload frontend/blog[Deployment] added
+added,{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,workload zeroday/zeroday[Deployment] added'
 }
 
 @test "roxctl-release connectivity-diff hould return error on not supported output format" {
@@ -484,9 +482,9 @@ payments/gateway[Deployment],payments/visa-processor-v2[Deployment],No Connectio
   assert_file_exist "$out_dir/out.txt"
   # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload payments/visa-processor-v2[Deployment] added)
-source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload frontend/blog[Deployment] added)
-source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, diff-type: added (workload zeroday/zeroday[Deployment] added)'
+diff-type: added, source: payments/gateway[Deployment], destination: payments/visa-processor-v2[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload payments/visa-processor-v2[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: frontend/blog[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload frontend/blog[Deployment] added
+diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  No Connections, dir2: TCP 8080, workloads-diff-info: workload zeroday/zeroday[Deployment] added'
 }
 
 @test "roxctl-release connectivity-diff generates conns diff report between resources from another two directories txt output" {
@@ -508,8 +506,8 @@ source: {ingress-controller}, destination: zeroday/zeroday[Deployment], dir1:  N
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
   assert_output --partial 'Connectivity diff:
-source: default/frontend[Deployment], destination: default/backend[Deployment], dir1:  TCP 9090, dir2: TCP 9090,UDP 53, diff-type: changed
-source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:  No Connections, dir2: TCP 9090, diff-type: added'
+diff-type: changed, source: default/frontend[Deployment], destination: default/backend[Deployment], dir1:  TCP 9090, dir2: TCP 9090,UDP 53
+diff-type: added, source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:  No Connections, dir2: TCP 9090'
 }
 
 @test "roxctl-release connectivity-diff generates conns diff report between resources from another two directories md output" {
@@ -530,10 +528,10 @@ source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
-  assert_output --partial '| source | destination | dir1 | dir2 | diff-type |
-|--------|-------------|------|------|-----------|
-| default/frontend[Deployment] | default/backend[Deployment] | TCP 9090 | TCP 9090,UDP 53 | changed |
-| 0.0.0.0-255.255.255.255 | default/backend[Deployment] | No Connections | TCP 9090 | added |'
+  assert_output --partial '| diff-type | source | destination | dir1 | dir2 | workloads-diff-info |
+|-----------|--------|-------------|------|------|---------------------|
+| changed | default/frontend[Deployment] | default/backend[Deployment] | TCP 9090 | TCP 9090,UDP 53 |  |
+| added | 0.0.0.0-255.255.255.255 | default/backend[Deployment] | No Connections | TCP 9090 |  |'
 }
 
 @test "roxctl-release connectivity-diff generates conns diff report between resources from another two directories csv output" {
@@ -554,9 +552,9 @@ source: 0.0.0.0-255.255.255.255, destination: default/backend[Deployment], dir1:
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
     # partial is used to filter WARN and INFO messages
-  assert_output --partial 'source,destination,dir1,dir2,diff-type
-default/frontend[Deployment],default/backend[Deployment],TCP 9090,"TCP 9090,UDP 53",changed
-0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 9090,added'
+  assert_output --partial 'diff-type,source,destination,dir1,dir2,workloads-diff-info
+changed,default/frontend[Deployment],default/backend[Deployment],TCP 9090,"TCP 9090,UDP 53",
+added,0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 9090,'
 }
 
 @test "roxctl-release connectivity-diff empty diff report for two paths with same directory " {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
@@ -40,8 +40,8 @@ teardown() {
 
 @test "roxctl-release connectivity-diff stops on first error when run with --fail" {
   mkdir -p "$out_dir"
-  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
-  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-011-XXXXXX-file1.yaml")"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-021-XXXXXX-file2.yaml")"
 
   run roxctl-release connectivity-diff "$out_dir/" "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
@@ -19,20 +19,28 @@ teardown() {
   rm -f "$ofile"
 }
 
-@test "roxctl-release connectivity-diff no args" {
-  run roxctl-release connectivity-diff
+@test "roxctl-release connectivity-diff illegal args" {
+  run roxctl-release connectivity-diff "dir1" "dir2"
   assert_failure
-  assert_line --partial "accepts 2 arg(s), received 0"
+  assert_line --partial "accepts 0 arg(s), received 2"
 }
 
-@test "roxctl-release connectivity-diff only one arg" {
-  run roxctl-release connectivity-diff "dir1"
+@test "roxctl-release connectivity-diff no input directories" {
+  run roxctl-release connectivity-diff
   assert_failure
-  assert_line --partial "accepts 2 arg(s), received 1"
+  assert_line --partial "ERROR:"
+  assert_line --partial "both directory paths dir1 and dir2 are require"
+}
+
+@test "roxctl-release connectivity-diff only one input directory" {
+  run roxctl-release connectivity-diff --dir1="dir1"
+  assert_failure
+  assert_line --partial "ERROR:"
+  assert_line --partial "both directory paths dir1 and dir2 are require"
 }
 
 @test "roxctl-release connectivity-diff non existing dirs" {
-  run roxctl-release connectivity-diff "$out_dir" "$out_dir"
+  run roxctl-release connectivity-diff --dir1="$out_dir" --dir2="$out_dir"
   assert_failure
   assert_line --partial "error in connectivity diff analysis"
   assert_line --partial "no such file or directory"
@@ -43,7 +51,7 @@ teardown() {
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-011-XXXXXX-file1.yaml")"
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-021-XXXXXX-file2.yaml")"
 
-  run roxctl-release connectivity-diff "$out_dir/" "$out_dir/" --remove --output-file=/dev/null --fail
+  run roxctl-release connectivity-diff --dir1="$out_dir/" --dir2="$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure
   assert_output --partial 'YAML document is malformed'
   assert_output --partial 'file1.yaml'
@@ -55,7 +63,7 @@ teardown() {
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-XXXXXX.yaml")"
 
   echo "Analyzing a corrupted yaml file '$templatedYaml'" >&3
-  run roxctl-release connectivity-diff "$out_dir/" "$out_dir/"
+  run roxctl-release connectivity-diff --dir1="$out_dir/" --dir2="$out_dir/"
   assert_failure
   assert_output --partial 'YAML document is malformed'
   assert_output --partial 'no relevant Kubernetes resources found'
@@ -71,7 +79,7 @@ teardown() {
   cp "${test_data}/np-guard/scenario-minimal-service/backend.yaml" "$out_dir/backend.yaml"
 
   echo "Analyzing a directory where 1/3 of yaml files are templated '$out_dir/'" >&3
-  run roxctl-release connectivity-diff "$out_dir/" "$out_dir/" --remove --output-file=/dev/null
+  run roxctl-release connectivity-diff --dir1="$out_dir/" --dir2="$out_dir/" --remove --output-file=/dev/null
   assert_failure
   assert_output --partial 'YAML document is malformed'
   refute_output --partial 'no relevant Kubernetes resources found'
@@ -84,7 +92,7 @@ teardown() {
   cp "${test_data}/np-guard/empty-yamls/empty.yaml" "$out_dir/empty.yaml"
   cp "${test_data}/np-guard/empty-yamls/empty2.yaml" "$out_dir/empty2.yaml"
 
-  run roxctl-release connectivity-diff "$out_dir/" "$out_dir/" --remove --output-file=/dev/null
+  run roxctl-release connectivity-diff --dir1="$out_dir/" --dir2="$out_dir/" --remove --output-file=/dev/null
   assert_failure
   assert_output --partial 'Yaml document is not a K8s resource'
   assert_output --partial 'no relevant Kubernetes resources found'
@@ -100,13 +108,13 @@ diff_tests_dir="${BATS_TEST_DIRNAME}/../../../../roxctl/connectivity-diff/testda
   assert_file_exist "${dir1}/namespace.yaml"
   assert_file_exist "${dir1}/route.yaml"
   # without strict it ignores the invalid yaml and continue
-  run roxctl-release connectivity-diff "${dir1}" "${dir1}" --remove --output-file=/dev/null
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir1}" --remove --output-file=/dev/null
   assert_success
   assert_output --partial 'WARN:'
   assert_output --partial 'Yaml document is not a K8s resource'
 
   # running with strict , a warning on invalid yaml doc is treated as error
-  run roxctl-release connectivity-diff "${dir1}" "${dir1}" --remove --output-file=/dev/null --strict
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir1}" --remove --output-file=/dev/null --strict
   assert_failure
   assert_output --partial 'WARN:'
   assert_output --partial 'Yaml document is not a K8s resource'
@@ -165,7 +173,7 @@ diff_tests_dir="${BATS_TEST_DIRNAME}/../../../../roxctl/connectivity-diff/testda
   assert_file_exist "${dir2}/zeroday/route.yaml"
   assert_file_exist "${dir2}/acs_netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}"
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}"
   assert_success
 
   echo "$output" > "$ofile"
@@ -228,7 +236,7 @@ diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Dep
   assert_file_exist "${dir2}/zeroday/route.yaml"
   assert_file_exist "${dir2}/acs_netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=txt
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=txt
   assert_success
 
   echo "$output" > "$ofile"
@@ -291,7 +299,7 @@ diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Dep
   assert_file_exist "${dir2}/zeroday/route.yaml"
   assert_file_exist "${dir2}/acs_netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=md
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=md
   assert_success
 
   echo "$output" > "$ofile"
@@ -355,7 +363,7 @@ diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Dep
   assert_file_exist "${dir2}/zeroday/route.yaml"
   assert_file_exist "${dir2}/acs_netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=csv
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=csv
   assert_success
 
   echo "$output" > "$ofile"
@@ -418,7 +426,7 @@ added,{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,w
   assert_file_exist "${dir2}/zeroday/route.yaml"
   assert_file_exist "${dir2}/acs_netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=png
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=png
   assert_failure
 
   assert_line --partial "error in formatting connectivity diff"
@@ -476,7 +484,7 @@ added,{ingress-controller},zeroday/zeroday[Deployment],No Connections,TCP 8080,w
   assert_file_exist "${dir2}/zeroday/route.yaml"
   assert_file_exist "${dir2}/acs_netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-file="$out_dir/out.txt"
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-file="$out_dir/out.txt"
   assert_success
 
   assert_file_exist "$out_dir/out.txt"
@@ -499,7 +507,7 @@ diff-type: added, source: {ingress-controller}, destination: zeroday/zeroday[Dep
   assert_file_exist "${dir2}/frontend.yaml"
   assert_file_exist "${dir2}/netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=txt
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=txt
   assert_success
 
   echo "$output" > "$ofile"
@@ -522,7 +530,7 @@ diff-type: added, source: 0.0.0.0-255.255.255.255, destination: default/backend[
   assert_file_exist "${dir2}/frontend.yaml"
   assert_file_exist "${dir2}/netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=md
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=md
   assert_success
 
   echo "$output" > "$ofile"
@@ -546,7 +554,7 @@ diff-type: added, source: 0.0.0.0-255.255.255.255, destination: default/backend[
   assert_file_exist "${dir2}/frontend.yaml"
   assert_file_exist "${dir2}/netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir2}" --output-format=csv
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir2}" --output-format=csv
   assert_success
 
   echo "$output" > "$ofile"
@@ -564,7 +572,7 @@ added,0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 909
   assert_file_exist "${dir1}/frontend.yaml"
   assert_file_exist "${dir1}/netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff "${dir1}" "${dir1}" 
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir1}" 
   assert_success
 
   echo "$output" > "$ofile"

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
@@ -572,7 +572,7 @@ added,0.0.0.0-255.255.255.255,default/backend[Deployment],No Connections,TCP 909
   assert_file_exist "${dir1}/frontend.yaml"
   assert_file_exist "${dir1}/netpols.yaml"
   echo "Writing diff report to ${ofile}" >&3
-  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir1}" 
+  run roxctl-release connectivity-diff --dir1="${dir1}" --dir2="${dir1}"
   assert_success
 
   echo "$output" > "$ofile"

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-diff-release.bats
@@ -29,14 +29,14 @@ teardown() {
   run roxctl-release connectivity-diff
   assert_failure
   assert_line --partial "ERROR:"
-  assert_line --partial "both directory paths dir1 and dir2 are require"
+  assert_line --partial "directory path dir1 is required"
 }
 
 @test "roxctl-release connectivity-diff only one input directory" {
   run roxctl-release connectivity-diff --dir1="dir1"
   assert_failure
   assert_line --partial "ERROR:"
-  assert_line --partial "both directory paths dir1 and dir2 are require"
+  assert_line --partial "directory path dir2 is required"
 }
 
 @test "roxctl-release connectivity-diff non existing dirs" {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-map-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-map-development.bats
@@ -259,9 +259,9 @@ acs_security_demos_dir="${BATS_TEST_DIRNAME}/../../../../roxctl/connectivity-map
   assert_file_exist "${acs_security_demos_dir}/payments/mastercard-processor/deployment.yaml"
   assert_file_exist "${acs_security_demos_dir}/payments/visa-processor/deployment.yaml"
   assert_file_exist "${acs_security_demos_dir}/acs_netpols.yaml"
-  run roxctl-development connectivity-map "${acs_security_demos_dir}" 
+  run roxctl-development connectivity-map "${acs_security_demos_dir}"
   assert_success
-  
+
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
@@ -278,7 +278,7 @@ frontend/webapp[Deployment] => backend/shipping[Deployment] : TCP 8080
 payments/gateway[Deployment] => payments/mastercard-processor[Deployment] : TCP 8080
 payments/gateway[Deployment] => payments/visa-processor[Deployment] : TCP 8080
 {ingress-controller} => frontend/asset-cache[Deployment] : TCP 8080
-{ingress-controller} => frontend/webapp[Deployment] : TCP 8080' 
+{ingress-controller} => frontend/webapp[Deployment] : TCP 8080'
 }
 
 @test "roxctl-development connectivity-map generates connlist for acs-security-demo md format" {
@@ -302,7 +302,7 @@ payments/gateway[Deployment] => payments/visa-processor[Deployment] : TCP 8080
   assert_file_exist "${acs_security_demos_dir}/acs_netpols.yaml"
   run roxctl-development connectivity-map "${acs_security_demos_dir}" --output-format=md
   assert_success
-  
+
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # output lines , skipping WARN and INFO messages

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-map-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-map-release.bats
@@ -259,9 +259,9 @@ acs_security_demos_dir="${BATS_TEST_DIRNAME}/../../../../roxctl/connectivity-map
   assert_file_exist "${acs_security_demos_dir}/payments/mastercard-processor/deployment.yaml"
   assert_file_exist "${acs_security_demos_dir}/payments/visa-processor/deployment.yaml"
   assert_file_exist "${acs_security_demos_dir}/acs_netpols.yaml"
-  run roxctl-release connectivity-map "${acs_security_demos_dir}" 
+  run roxctl-release connectivity-map "${acs_security_demos_dir}"
   assert_success
-  
+
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # partial is used to filter WARN and INFO messages
@@ -278,7 +278,7 @@ frontend/webapp[Deployment] => backend/shipping[Deployment] : TCP 8080
 payments/gateway[Deployment] => payments/mastercard-processor[Deployment] : TCP 8080
 payments/gateway[Deployment] => payments/visa-processor[Deployment] : TCP 8080
 {ingress-controller} => frontend/asset-cache[Deployment] : TCP 8080
-{ingress-controller} => frontend/webapp[Deployment] : TCP 8080' 
+{ingress-controller} => frontend/webapp[Deployment] : TCP 8080'
 }
 
 @test "roxctl-release connectivity-map generates connlist for acs-security-demo md format" {
@@ -302,7 +302,7 @@ payments/gateway[Deployment] => payments/visa-processor[Deployment] : TCP 8080
   assert_file_exist "${acs_security_demos_dir}/acs_netpols.yaml"
   run roxctl-release connectivity-map "${acs_security_demos_dir}" --output-format=md
   assert_success
-  
+
   echo "$output" > "$ofile"
   assert_file_exist "$ofile"
   # output lines , skipping WARN and INFO messages

--- a/tests/roxctl/bats-tests/test-data/np-guard/irrelevant-oc-resource-example/irrelevant_oc_resource.yaml
+++ b/tests/roxctl/bats-tests/test-data/np-guard/irrelevant-oc-resource-example/irrelevant_oc_resource.yaml
@@ -20,8 +20,8 @@ readOnlyRootFilesystem: false
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: asset-cache 
-  namespace: frontend 
+  name: asset-cache
+  namespace: frontend
   labels:
     app: asset-cache
 spec:


### PR DESCRIPTION
explaining changes  on cta.go from first new commit 819483c5de1a618b0eeafd21274384b54b90eeae :
-> when a severe error is raised, `analyzer.ConnDiffFromDirPaths`, returns an empty `connsDiff` var , so when` –fail` is on, we expect to stop. (not continuing to `analyzer.ConnectivityDiffToString(connsDiff)` call

output before the changes: (and before v0.4.3 fixes): 
![image](https://github.com/stackrox/stackrox/assets/82180114/07c144a3-2dd2-41b9-9ad8-761885344b95)
we didn’t want to see “No connections diff” message


output after the changes:
![image](https://github.com/stackrox/stackrox/assets/82180114/f201a916-41b7-4583-9f50-a98b3ec4844d)

->Also checking errors are according to following paragraph from RREADME.md:

> Using the `--strict` parameter produces an error "there were errors during execution" if any warnings appeared during the processing. Note that the combination of `--strict` and `--fail` will not stop on the first warning, as the interpretation of warnings as errors happens at the end of execution.
